### PR TITLE
[WIP] Amazonia-1 using the new us-west-2 endpoint

### DIFF
--- a/stactools_pipelines/pipelines/amazonia_1/config.yaml
+++ b/stactools_pipelines/pipelines/amazonia_1/config.yaml
@@ -3,7 +3,7 @@
   compute: "awslambda"
   secret_arn: "arn:aws:secretsmanager:eu-central-1:751953039297:secret:asdi-auth-stack-alukach/asdi-workflows-6awSos"
   ingestor_url: "https://crtx3178aa.execute-api.us-west-2.amazonaws.com/dev"
-  sns: "arn:aws:sns:us-east-1:599544552497:NewAMQuicklook"
+  sns: "arn:aws:sns:us-west-2:599544552497:NewAM1Quicklook"
   # inventory_location: ""
   # historic_frequency: 1
   # initial_chunk: ""

--- a/stactools_pipelines/pipelines/amazonia_1/requirements.txt
+++ b/stactools_pipelines/pipelines/amazonia_1/requirements.txt
@@ -1,4 +1,4 @@
 aws-lambda-powertools
 jmespath
-stactools-amazonia-1 >= 0.1.2
+stactools-amazonia-1 >= 0.1.3
 s3fs

--- a/stactools_pipelines/pipelines/amazonia_1/test_app.py
+++ b/stactools_pipelines/pipelines/amazonia_1/test_app.py
@@ -33,7 +33,7 @@ def test_xml_key_from_quicklook_key():
 
 @pytest.mark.parametrize("pipeline_id", ["amazonia_1"])
 @pytest.mark.parametrize("module", ["app"])
-@pytest.mark.parametrize("bucket", ["amazonia-pds"])
+@pytest.mark.parametrize("bucket", ["brazil-eosats"])
 @pytest.mark.parametrize("key", [KEY])
 def test_handler(
     mock_env,  # pylint: disable=unused-argument


### PR DESCRIPTION
## What I am changing
AMZ-1 pipeline using the new us-west-2 endpoint and creating assets referencing the new bucket.

## How I did it
Update pipeline conf (new amazonia_1 pkg stactools release) and bucket name in stac item generation.

## How you can test it
That is why the PR is WIP, running
```bash
(export PIPELINE="amazonia_1" && tox)
```
Returns an error on a different pipeline:
```bash
py39 run-test: commands[0] | flake8
./stactools_pipelines/pipelines/aws_noaa_oisst_avhrr_only/test_app.py:15:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
./stactools_pipelines/pipelines/aws_noaa_oisst_avhrr_only/test_collection.py:15:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
ERROR: InvocationError for command /home/liporace/github/stactools-pipelines/toxenv/bin/flake8 (exited with code 1)
```

Please advise on updated instructions to run the test for a single pipeline.

## Related Issues

https://github.com/stactools-packages/amazonia-1/issues/15