### PR TITLE
chore: update core

### DIFF
--- a/stactools_pipelines/models/pipeline.py
+++ b/stactools_pipelines/models/pipeline.py
@@ -14,7 +14,7 @@ class Pipeline(BaseModel):
     compute: ComputeEnum
     secret_arn: str
     ingestor_url: str
-    sns: Optional[str]
+    sns: Optional[str] = None
     inventory_location: Optional[str] = None
     historic_frequency: Optional[int] = None
     initial_chunk: Optional[str] = None

--- a/stactools_pipelines/pipelines/aws_noaa_oisst_avhrr_only/test_app.py
+++ b/stactools_pipelines/pipelines/aws_noaa_oisst_avhrr_only/test_app.py
@@ -12,7 +12,7 @@ from stactools_pipelines.pipelines.aws_noaa_oisst_avhrr_only.app import handler
 
 def test_create_item():
     item = module_create_item()
-    assert type(item) == pystac.item.Item
+    assert isinstance(item, pystac.Item)
 
 
 @pytest.mark.parametrize("pipeline_id", ["aws_noaa_oisst_avhrr_only"])

--- a/stactools_pipelines/pipelines/aws_noaa_oisst_avhrr_only/test_collection.py
+++ b/stactools_pipelines/pipelines/aws_noaa_oisst_avhrr_only/test_collection.py
@@ -12,7 +12,7 @@ from stactools_pipelines.pipelines.aws_noaa_oisst_avhrr_only.collection import h
 
 def test_create_collection():
     collection = module_create_collection()
-    assert type(collection) == pystac.collection.Collection
+    assert isinstance(collection, pystac.Collection)
 
 
 @pytest.mark.parametrize("pipeline_id", ["aws_noaa_oisst_avhrr_only"])


### PR DESCRIPTION
## Description
Cherry-picked commits from https://github.com/developmentseed/stactools-pipelines/pull/44

## FIXED
- optional values for ComputeEnum
- flake8 updates

## CHANGED
- bumped aws-cdk/aws-cdk-lib versions for lambda default node18 runtime (node14 no longer supported)

(looks like the model_validator was already added)