### PR TITLE
fix: use dev stack secret

### DIFF
--- a/stactools_pipelines/pipelines/amazonia_1/config.yaml
+++ b/stactools_pipelines/pipelines/amazonia_1/config.yaml
@@ -1,7 +1,7 @@
 ---
   id: "amazonia_1"
   compute: "awslambda"
-  secret_arn: "arn:aws:secretsmanager:eu-central-1:751953039297:secret:asdi-auth-stack-dev/asdi-workflows-6awSos"
+  secret_arn: "arn:aws:secretsmanager:eu-central-1:751953039297:secret:asdi-auth-stack-dev/asdi-workflows-fSzAw7"
   ingestor_url: "https://crtx3178aa.execute-api.us-west-2.amazonaws.com/dev"
   sns: "arn:aws:sns:us-east-1:599544552497:NewAMQuicklook"
   # inventory_location: ""

--- a/stactools_pipelines/pipelines/amazonia_1/config.yaml
+++ b/stactools_pipelines/pipelines/amazonia_1/config.yaml
@@ -1,7 +1,7 @@
 ---
   id: "amazonia_1"
   compute: "awslambda"
-  secret_arn: "arn:aws:secretsmanager:eu-central-1:751953039297:secret:asdi-auth-stack-alukach/asdi-workflows-6awSos"
+  secret_arn: "arn:aws:secretsmanager:eu-central-1:751953039297:secret:asdi-auth-stack-dev/asdi-workflows-6awSos"
   ingestor_url: "https://crtx3178aa.execute-api.us-west-2.amazonaws.com/dev"
   sns: "arn:aws:sns:us-east-1:599544552497:NewAMQuicklook"
   # inventory_location: ""

--- a/stactools_pipelines/pipelines/aws_noaa_oisst_avhrr_only/config.yaml
+++ b/stactools_pipelines/pipelines/aws_noaa_oisst_avhrr_only/config.yaml
@@ -1,5 +1,5 @@
 ---
   id: "aws_noaa_oisst_avhrr_only"
   compute: "awslambda"
-  secret_arn: "arn:aws:secretsmanager:eu-central-1:751953039297:secret:asdi-auth-stack-alukach/asdi-workflows-6awSos"
+  secret_arn: "arn:aws:secretsmanager:eu-central-1:751953039297:secret:asdi-auth-stack-dev/asdi-workflows-6awSos"
   ingestor_url: "https://crtx3178aa.execute-api.us-west-2.amazonaws.com/dev"

--- a/stactools_pipelines/pipelines/aws_noaa_oisst_avhrr_only/config.yaml
+++ b/stactools_pipelines/pipelines/aws_noaa_oisst_avhrr_only/config.yaml
@@ -1,5 +1,5 @@
 ---
   id: "aws_noaa_oisst_avhrr_only"
   compute: "awslambda"
-  secret_arn: "arn:aws:secretsmanager:eu-central-1:751953039297:secret:asdi-auth-stack-dev/asdi-workflows-6awSos"
+  secret_arn: "arn:aws:secretsmanager:eu-central-1:751953039297:secret:asdi-auth-stack-dev/asdi-workflows-fSzAw7"
   ingestor_url: "https://crtx3178aa.execute-api.us-west-2.amazonaws.com/dev"

--- a/stactools_pipelines/pipelines/cop_dem_30/config.yaml
+++ b/stactools_pipelines/pipelines/cop_dem_30/config.yaml
@@ -1,7 +1,7 @@
 ---
   id: "cop_dem_30"
   compute: "awslambda"
-  secret_arn: "arn:aws:secretsmanager:eu-central-1:751953039297:secret:asdi-auth-stack-alukach/asdi-workflows-6awSos"
+  secret_arn: "arn:aws:secretsmanager:eu-central-1:751953039297:secret:asdi-auth-stack-dev/asdi-workflows-6awSos"
   ingestor_url: "https://crtx3178aa.execute-api.us-west-2.amazonaws.com/dev"
   inventory_location: "s3://asdi-athena-testing-eu-central-1/inventories/copernicus-dem-30m.csv"
   historic_frequency: 0

--- a/stactools_pipelines/pipelines/cop_dem_30/config.yaml
+++ b/stactools_pipelines/pipelines/cop_dem_30/config.yaml
@@ -1,7 +1,7 @@
 ---
   id: "cop_dem_30"
   compute: "awslambda"
-  secret_arn: "arn:aws:secretsmanager:eu-central-1:751953039297:secret:asdi-auth-stack-dev/asdi-workflows-6awSos"
+  secret_arn: "arn:aws:secretsmanager:eu-central-1:751953039297:secret:asdi-auth-stack-dev/asdi-workflows-fSzAw7"
   ingestor_url: "https://crtx3178aa.execute-api.us-west-2.amazonaws.com/dev"
   inventory_location: "s3://asdi-athena-testing-eu-central-1/inventories/copernicus-dem-30m.csv"
   historic_frequency: 0

--- a/stactools_pipelines/pipelines/noaa_oisst/config.yaml
+++ b/stactools_pipelines/pipelines/noaa_oisst/config.yaml
@@ -1,7 +1,7 @@
 ---
   id: "noaa_oisst"
   compute: "awslambda"
-  secret_arn: "arn:aws:secretsmanager:eu-central-1:751953039297:secret:asdi-auth-stack-alukach/asdi-workflows-6awSos"
+  secret_arn: "arn:aws:secretsmanager:eu-central-1:751953039297:secret:asdi-auth-stack-dev/asdi-workflows-6awSos"
   ingestor_url: "https://crtx3178aa.execute-api.us-west-2.amazonaws.com/dev"
   sns: "arn:aws:sns:us-east-1:709902155096:NewCDRSeaSurfTempOptInterpObject"
   inventory_location: "s3://nodd-bucket-inventory/noaa-cdr-sea-surface-temp-optimum-interpolation-pds/DailyCSV/hive/dt=2023-04-24-01-00/"

--- a/stactools_pipelines/pipelines/noaa_oisst/config.yaml
+++ b/stactools_pipelines/pipelines/noaa_oisst/config.yaml
@@ -1,7 +1,7 @@
 ---
   id: "noaa_oisst"
   compute: "awslambda"
-  secret_arn: "arn:aws:secretsmanager:eu-central-1:751953039297:secret:asdi-auth-stack-dev/asdi-workflows-6awSos"
+  secret_arn: "arn:aws:secretsmanager:eu-central-1:751953039297:secret:asdi-auth-stack-dev/asdi-workflows-fSzAw7"
   ingestor_url: "https://crtx3178aa.execute-api.us-west-2.amazonaws.com/dev"
   sns: "arn:aws:sns:us-east-1:709902155096:NewCDRSeaSurfTempOptInterpObject"
   inventory_location: "s3://nodd-bucket-inventory/noaa-cdr-sea-surface-temp-optimum-interpolation-pds/DailyCSV/hive/dt=2023-04-24-01-00/"

--- a/stactools_pipelines/pipelines/sentinel1/config.yaml
+++ b/stactools_pipelines/pipelines/sentinel1/config.yaml
@@ -1,7 +1,7 @@
 ---
   id: "sentinel1"
   compute: "awslambda"
-  secret_arn: "arn:aws:secretsmanager:eu-central-1:751953039297:secret:asdi-auth-stack-alukach/asdi-workflows-6awSos"
+  secret_arn: "arn:aws:secretsmanager:eu-central-1:751953039297:secret:asdi-auth-stack-dev/asdi-workflows-6awSos"
   ingestor_url: "https://crtx3178aa.execute-api.us-west-2.amazonaws.com/dev"
   sns: "arn:aws:sns:eu-central-1:214830741341:SentinelS1L1C"
   inventory_location: "s3://sentinel-inventory/sentinel-s1-l1c/sentinel-s1-l1c-inventory/hive/dt=2022-11-16-01-00/"

--- a/stactools_pipelines/pipelines/sentinel1/config.yaml
+++ b/stactools_pipelines/pipelines/sentinel1/config.yaml
@@ -1,7 +1,7 @@
 ---
   id: "sentinel1"
   compute: "awslambda"
-  secret_arn: "arn:aws:secretsmanager:eu-central-1:751953039297:secret:asdi-auth-stack-dev/asdi-workflows-6awSos"
+  secret_arn: "arn:aws:secretsmanager:eu-central-1:751953039297:secret:asdi-auth-stack-dev/asdi-workflows-fSzAw7"
   ingestor_url: "https://crtx3178aa.execute-api.us-west-2.amazonaws.com/dev"
   sns: "arn:aws:sns:eu-central-1:214830741341:SentinelS1L1C"
   inventory_location: "s3://sentinel-inventory/sentinel-s1-l1c/sentinel-s1-l1c-inventory/hive/dt=2022-11-16-01-00/"


### PR DESCRIPTION
Not sure why these pipelines are using my dev Cognito instance. I could easily see myself or anyone else deleting the `asdi-auth-stack-alukach` stack without much thought.  

Looking at the secrets, they point to the cognito name used for auth so I believe a direct switch of the secret will point the pipelines at the correct cognito instance (they all seem to use the same client).

```json
{
  "flow": "client_credentials", 
  "cognito_domain": "https://asdi-auth-stack-dev.auth.us-west-2.amazoncognito.com", 
  "client_id": "...", 
  "client_secret": "...", 
  "scope": "asdi-stac-ingestion-registry-server/stac:register"
}
```

> [!CAUTION]
> I admit that I don't understand how this system ever worked. If different pipelines were using different Cognito user pools for auth, how were they able to send requests to the same STAC Ingestor instance? The STAC Ingestor should validate tokens against a single user pool's JWKS. 
> https://github.com/developmentseed/stactools-pipelines/blob/d8218501e00589ef00e3cc8940401a3eb141e8fa/stactools_pipelines/pipelines/noaa_hrrr/config.yaml#L4-L5