### PR TITLE
feat: cache M2M JWTs between pipeline runs

### DIFF
--- a/stactools_pipelines/cdk/app.py
+++ b/stactools_pipelines/cdk/app.py
@@ -3,6 +3,7 @@ import os
 import aws_cdk as cdk
 import yaml
 
+from stactools_pipelines.cdk.jwt_cache_stack import JwtCacheStack
 from stactools_pipelines.cdk.lambda_stack import LambdaStack
 from stactools_pipelines.models.pipeline import Pipeline
 
@@ -10,17 +11,23 @@ from stactools_pipelines.models.pipeline import Pipeline
 pipeline = os.environ["PIPELINE"]
 stack_name = pipeline.replace("_", "-")
 
+app = cdk.App()
+
+jwt_cache_stack = JwtCacheStack(
+    app,
+    stack_name,
+)
+
 with open(f"./stactools_pipelines/pipelines/{pipeline}/config.yaml") as f:
     config = yaml.safe_load(f)
     pipeline = Pipeline(**config)
-
-    app = cdk.App()
 
     # For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html
     LambdaStack(
         app,
         stack_name,
         pipeline,
+        jwt_cache_table=jwt_cache_stack.table,
     )
 
     for k, v in dict(

--- a/stactools_pipelines/cdk/jwt_cache_stack.py
+++ b/stactools_pipelines/cdk/jwt_cache_stack.py
@@ -1,0 +1,25 @@
+import aws_cdk as cdk
+import aws_cdk.aws_dynamodb as dynamodb
+from constructs import Construct
+
+
+class JwtCacheStack(cdk.Stack):
+    def __init__(
+        self,
+        scope: Construct,
+        stack_name: str,
+        **kwargs,
+    ) -> None:
+        super().__init__(scope, stack_name, **kwargs)
+
+        self.table = dynamodb.Table(
+            self,
+            id=f"{stack_name}-jwt-cache",
+            partition_key=dynamodb.Attribute(
+                name="client_id",
+                type=dynamodb.AttributeType.STRING,
+            ),
+            billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,  # On-demand pricing
+            time_to_live_attribute="ttl",  # Attribute to store TTL (epoch seconds)
+            removal_policy=cdk.RemovalPolicy.DESTROY,  # For dev/test, change as needed
+        )

--- a/stactools_pipelines/cdk/lambda_stack.py
+++ b/stactools_pipelines/cdk/lambda_stack.py
@@ -1,4 +1,5 @@
 import aws_cdk as cdk
+import aws_cdk.aws_dynamodb as dynamodb
 import aws_cdk.aws_sns as sns
 import aws_cdk.aws_sns_subscriptions as sns_subscriptions
 from constructs import Construct
@@ -11,12 +12,13 @@ from stactools_pipelines.models.pipeline import Pipeline
 
 
 class LambdaStack(cdk.Stack):
+
     def __init__(
         self,
         scope: Construct,
         stack_name: str,
         pipeline: Pipeline,
-        **kwargs,
+        jwt_cache_table: dynamodb.Table,
     ) -> None:
         super().__init__(scope, stack_name)
         self.collection_function = PipelineFunction(
@@ -35,6 +37,7 @@ class LambdaStack(cdk.Stack):
             self,
             id=f"{stack_name}-granule_function",
             pipeline=pipeline,
+            jwt_cache_table=jwt_cache_table,
         )
 
         if pipeline.sns or pipeline.inventory_location:

--- a/stactools_pipelines/cdk/pipeline_function.py
+++ b/stactools_pipelines/cdk/pipeline_function.py
@@ -1,4 +1,5 @@
 import aws_cdk as cdk
+import aws_cdk.aws_dynamodb as dynamodb
 import aws_cdk.aws_ecr as ecr
 import aws_cdk.aws_iam as iam
 import aws_cdk.aws_lambda as aws_lambda
@@ -10,11 +11,13 @@ from stactools_pipelines.models.pipeline import Pipeline
 
 
 class PipelineFunction(Construct):
+
     def __init__(
         self,
         scope: Construct,
         id: str,
         pipeline: Pipeline,
+        jwt_cache_table: dynamodb.Table,
         collection: bool = False,
         *,
         prefix=None,
@@ -57,8 +60,11 @@ class PipelineFunction(Construct):
                 ).to_string(),
                 "SCOPE": self.secret.secret_value_from_json("scope").to_string(),
                 "INGESTOR_URL": pipeline.ingestor_url,
+                "JWT_CACHE_TABLE": jwt_cache_table.table_arn,
             },
         )
+        jwt_cache_table.grant_read_write_data(self.function)
+
         self.open_buckets_statement = iam.PolicyStatement(
             resources=[
                 "arn:aws:s3:::*",

--- a/stactools_pipelines/cognito/utils.py
+++ b/stactools_pipelines/cognito/utils.py
@@ -1,6 +1,41 @@
 import os
-
+import time
 import requests
+from typing import Optional
+
+import boto3
+
+
+class JwtCache:
+    """
+    A DynamoDB cache for JWT tokens. Used to avoid high fees for M2M authentication in
+    Cognito.
+    """
+
+    def __init__(self):
+        self.dynamodb = boto3.resource("dynamodb")
+        self.table = self.dynamodb.Table(os.environ["JWT_CACHE_TABLE"])
+
+    def get_token(self, client_id: str) -> Optional[str]:
+        response = self.table.get_item(Key={"client_id": client_id})
+        item = response.get("Item")
+        if not item:
+            return None
+
+        now = int(time.time())
+        if item.get("expires_at", 0) > now:
+            return item.get("jwt")
+        return None
+
+    def set_token(self, client_id: str, jwt: str, expires_at: int):
+        self.table.put_item(
+            Item={
+                "client_id": client_id,
+                "jwt": jwt,
+                "expires_at": expires_at,
+                "created_at": int(time.time()),
+            }
+        )
 
 
 def get_token() -> str:
@@ -8,6 +43,14 @@ def get_token() -> str:
     client_secret = os.environ["CLIENT_SECRET"]
     client_id = os.environ["CLIENT_ID"]
     scope = os.environ["SCOPE"]
+
+    # Try to get a non-expired JWT from the cache
+    cache = JwtCache()
+    jwt = cache.get_token(client_id)
+    if jwt:
+        return jwt
+
+    # No valid JWT found, get a new one from Cognito
     response = requests.post(
         f"{domain}/oauth2/token",
         headers={
@@ -26,4 +69,15 @@ def get_token() -> str:
         print(response.text)
         raise
 
-    return response.json()["access_token"]
+    data = response.json()
+    jwt = data["access_token"]
+
+    # Store the new JWT in the cache
+    cache = JwtCache()
+    cache.set_token(
+        client_id,
+        jwt=jwt,
+        expires_at=data["exp"] - (60 * 1000),  # expire 1 min early for safety
+    )
+
+    return jwt


### PR DESCRIPTION
In this PR, we introduce a new `JwtCacheStack` that creates a DynamoDB table to store JWTs for ingestion pipelines.  This should reduce the amount of JWTs being fetched from Cognito and thus reduce the cost increase we saw after AWS increased pricing for M2M usage[^pricing].

DynamoDB was chosen over Secrets Manager or Parameter Store as it is designed to be lower latency and has lower costs than the other two services.

[^pricing]: https://aws.amazon.com/about-aws/whats-new/2024/05/amazon-cognito-tiered-pricing-m2m-usage/